### PR TITLE
Fixes phi-function.html denominator error. Should be 1/p and not 1/(p)^n .

### DIFF
--- a/algebra/phi-function.html
+++ b/algebra/phi-function.html
@@ -67,7 +67,7 @@ If</p>
   
   <p>$\phi (n) = \phi ({P_{1}}^{a_{1}}) \cdot \phi ({P_{2}}^{a_{2}}) \cdot  \ldots  \cdot \phi ({P_{k}}^{a_{k}})$<br />
   $= ({P_{1}}^{a_{1}} - {P_{1}}^{a_{1} - 1}) \cdot ({P_{2}}^{a_{2}} - {P_{2}}^{a_{2} - 1}) \cdot \ldots \cdot ({P_{k}}^{a_{k}} - {P_{k}}^{a_{k} - 1})$<br />
-  $= n \cdot (1 - \frac{1}{{P_{1}}^{a_{1}}}) \cdot (1 - \frac{1}{{P_{2}}^{a_{2}}}) \cdot \ldots \cdot (1 - \frac{1}{{P_{k}}^{a_{k}}})$</p>
+  $= n \cdot (1 - \frac{1}{P_{1}}) \cdot (1 - \frac{1}{P_{2}}) \cdot \ldots \cdot (1 - \frac{1}{P_{k}})$</p>
 </blockquote>
 
 <h3>Algorithm</h3>


### PR DESCRIPTION
Fixes phi-function.html denominator error. Should be 1/p and not 1/(p)^n .